### PR TITLE
Bump upstream version to v1.15.9

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ros-noetic-roscpp
 	pkgdesc = ROS - roscpp is a C++ implementation of ROS.
-	pkgver = 1.15.8
+	pkgver = 1.15.9
 	pkgrel = 1
 	url = https://github.com/ros/ros_comm
 	arch = i686
@@ -32,8 +32,8 @@ pkgbase = ros-noetic-roscpp
 	depends = ros-noetic-rosconsole
 	depends = ros-noetic-roscpp-serialization
 	depends = ros-noetic-message-runtime
-	source = ros-noetic-roscpp-1.15.8.tar.gz::https://github.com/ros/ros_comm/archive/1.15.8.tar.gz
-	sha256sums = 7a72219b236aef5f0327c3ce6eba6008980a24a986a5b970b17125890887b494
+	source = ros-noetic-roscpp-1.15.9.tar.gz::https://github.com/ros/ros_comm/archive/1.15.9.tar.gz
+	sha256sums = ee68c16fe6e2f3bf8fef4cf35552a30160cb3b579dfe18d667c0ba05e69ef90d
 
 pkgname = ros-noetic-roscpp
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@ pkgdesc="ROS - roscpp is a C++ implementation of ROS."
 url='https://github.com/ros/ros_comm'
 
 pkgname='ros-noetic-roscpp'
-pkgver='1.15.8'
+pkgver='1.15.9'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
 pkgrel=1
 license=('BSD')
@@ -46,7 +46,7 @@ depends=(
 
 _dir="ros_comm-${pkgver}/clients/roscpp"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/ros_comm/archive/${pkgver}.tar.gz")
-sha256sums=('7a72219b236aef5f0327c3ce6eba6008980a24a986a5b970b17125890887b494')
+sha256sums=('ee68c16fe6e2f3bf8fef4cf35552a30160cb3b579dfe18d667c0ba05e69ef90d')
 
 build() {
     # Use ROS environment variables.


### PR DESCRIPTION
In trying to figure out why it wasn't compiling for me (issue #1) I tried building upstream v1.15.9, which seems to fix the issue. Rebuilding the package using this version solves things.

Closes #1.